### PR TITLE
Fix the composer provide rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
   "provide": {
     "psr/container-implementation": "^1.0",
     "psr/http-message-implementation": "^1.0",
-    "psr/http-server-handler": "^1.0",
+    "psr/http-server-handler-implementation": "^1.0",
     "psr/log-implementation": "^1.0",
     "psr/simple-cache-implementation": "^1.0"
   },


### PR DESCRIPTION
This package does not provide the code of the psr/http-server-handler package (which defines interfaces). It provides psr/http-server-handler-implementation which is the virtual package to represent implementations of the interface.
Providing the wrong package while also requiring it creates issues with Composer 2, because the solver will consider that install psr/http-server-handler is not necessary as it is already provided.

Refs composer/composer#9316